### PR TITLE
[Documentation]Adding example customization documents

### DIFF
--- a/images/tkg/docs/examples/README.md
+++ b/images/tkg/docs/examples/README.md
@@ -1,1 +1,8 @@
-# Placeholder for Samples folder
+# Examples
+
+This document gives information about different customization examples to customize a Node image for Tanzu on vSphere.
+
+- [Configuring Packer HTTP server port](configuring_packer_http_port.md)
+- [Changing VM Hardware Version(VMX version)](changing_hardware_version.md)
+- [Adding new OS packages and configuring the repositories or sources](adding_os_pkg_repos.md).
+- [Running Prometheus node exporter service on the nodes](prometheus_node_exporter.md)

--- a/images/tkg/docs/examples/adding_os_pkg_repos.md
+++ b/images/tkg/docs/examples/adding_os_pkg_repos.md
@@ -1,0 +1,109 @@
+# Adding new OS packages and configuring the repositories or sources
+
+## Use case
+
+As a user I want to
+
+1. Add new OS packages such as `pkg1` and `pkg2`.
+2. Configure sources/repositories to an internal mirror to build the node images in an air-gapped scenario. Configuring new sources/repositories is also useful when we want to install internally built software.
+
+## Customization
+
+Configuration of OS packages and sources/repositories is exposed as packer variables. To view a list of packer variables exposed by [kubernetes image builder][kubernetes-image-builder] please refer to this [page][customizations-doc].
+
+### Adding new packages
+
+To add new packages [kubernetes image builder][kubernetes-image-builder] provides `extra_rpms` and `extra_debs` packer variables for Photon and Ubuntu respectively. To add new packages, add the packages to the packer variables in the [default-args.j2][default-args] file as shown below.
+
+_**Note**: If you are building just the Ubuntu OS node image you will not have to modify the photon OS block._
+
+```jinja
+    {% if os_type == "photon-3" %}
+    "distro_version": "3.0",
+    "extra_rpms": "existing_packages pkg1 pkg2"
+    {% elif os_type == "ubuntu-2004-efi" %}
+    "extra_debs": "existing_packages pkg1 pkg2",
+    "boot_disable_ipv6": "1"
+    {% endif %}
+```
+
+### Configuring new sources/repositories
+
+[kubernetes image builder][kubernetes-image-builder] provides `extra_repos` packer variables through which sources/repositories can be configured for both Photon and Ubuntu. As there is a difference in how Ubuntu/Photon sources are configured we need to have separate source files for Photon/Ubuntu.
+
+- Create new folder `repos` in [ansible files](./../../../ansible/files/) folder
+- Create a new file for Photon sources called `photon.repo` in the `repos` folder. Refer below for sample content and refer to the official Photon [document][photon-repo-doc] for more information
+
+```text
+[photon]
+name=VMware Photon Linux $releasever ($basearch)
+baseurl=<internal_mirror_url>/$releasever/photon_release_$releasever_$basearch
+gpgkey=<gpg_key>
+gpgcheck=1
+enabled=1
+
+[photon-updates]
+name=VMware Photon Linux $releasever ($basearch) Updates
+baseurl=<internal_mirror_url>/$releasever/photon_updates_$releasever_$basearch
+gpgkey=<gpg_key>
+gpgcheck=1
+enabled=1
+
+[photon-extras]
+name=VMware Photon Extras $releasever ($basearch)
+baseurl=<internal_mirror_url>/$releasever/photon_extras_$releasever_$basearch
+gpgkey=<gpg_key>
+gpgcheck=1
+enabled=1
+```
+
+- Create a new file for Ubuntu sources called `ubuntu.list` in the `repos` folder. Refer to the official ubuntu [documentation][ubuntu-sources-doc] for more information.
+  - _**Note**: `focal` is for ubuntu 20.04 so this needs to be changed if the ubuntu version is also changed example for ubuntu 22.04 it is `jammy`_
+
+```text
+deb <internal_source_url> focal main restricted universe
+deb <internal_source_url> focal-security main restricted
+deb <internal_source_url> focal-updates main restricted
+```
+
+- Create a new file `repos.j2` or `repos.json` in [packer-variables](./../../packer-variables/) folder for configuring the `extra_repos` packer variable folder. (Uses [jinja][jinja] templating)
+
+```jinja
+{
+    {% if os_type == "photon-3" %}
+    "extra_repos": "/image-builder/images/capi/image/ansible/files/repos/photon.repo"
+    {% elif os_type == "ubuntu-2004-efi" %}
+    "extra_repos": "/image-builder/images/capi/image/ansible/files/repos/ubuntu.list"
+    {% endif %}
+}
+```
+
+### Disabling public repositories/sources
+
+For disabling public repos set the `disable_public_repos` packer variable to `true` in the `repos.j2` file.
+
+### Removing the extra repositories/sources
+
+To remove the extra repositories/sources that were configured during the image build process set the `remove_extra_repos` packer variable to `true`.
+
+```jinja
+{
+    "disable_public_repos": true,
+    "remove_extra_repos": true
+    {% if os_type == "photon-3" %}
+    "extra_repos": "/image-builder/images/capi/image/ansible/files/repos/photon.repo"
+    {% elif os_type == "ubuntu-2004-efi" %}
+    "extra_repos": "/image-builder/images/capi/image/ansible/files/repos/ubuntu.list"
+    {% endif %}
+}
+```
+
+[//]: Links
+
+[ansible-files]: [./../../../ansible/files/]
+[customizations-doc]: https://image-builder.sigs.k8s.io/capi/capi.html#customization
+[default-args]: [./../../../packer-variables/default-args.j2]
+[jinja]: https://jinja.palletsprojects.com/en/3.1.x/
+[kubernetes-image-builder]: https://github.com/kubernetes-sigs/image-builder/
+[photon-repo-doc]: https://vmware.github.io/photon/assets/files/html/3.0/photon_admin/adding-a-new-repository.html
+[ubuntu-sources-doc]: https://manpages.ubuntu.com/manpages/focal/man5/sources.list.5.html

--- a/images/tkg/docs/examples/changing_hardware_version.md
+++ b/images/tkg/docs/examples/changing_hardware_version.md
@@ -1,0 +1,25 @@
+# Changing the Hardware version
+
+## Use case
+
+As a customer, I want to change the Hardware version of the node image to use the latest hardware functionalities.
+
+## Background
+
+By default, node images use the hardware version(`VMX`) 17. Please refer to the below documents to learn more about the hardware version and its compatibility with the vSphere environment.
+
+- [Hardware Features Available with Virtual Machine Compatibility Settings](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+- [ESXi/ESX hosts and compatible virtual machine hardware versions list](https://kb.vmware.com/s/article/2007240)
+
+## Customization
+
+[Kubernetes Image Builder][kubernetes-image-builder] has a `vmx_version` packer variable through which the hardware version can be configured. Edit the `vmx_version` filed in the [default-args.j2][default-args] present in [packer variables](./../../packer-variables/) folder with the appropriate hardware version and build the image
+
+```text
+    "vmx_version": "17",
+```
+
+[//]: Links
+
+[default-args]: [./../../../packer-variables/default-args.j2]
+[kubernetes-image-builder]: https://github.com/kubernetes-sigs/image-builder/

--- a/images/tkg/docs/examples/configuring_packer_http_port.md
+++ b/images/tkg/docs/examples/configuring_packer_http_port.md
@@ -1,0 +1,29 @@
+# Configuring the Packer HTTP port
+
+As a customer, I want to configure the port or port range used by the Packer HTTP service during the Node Image build process.
+
+## Backgroud
+
+For unattended installation during the image build process photon preseed approach where the [kickstart](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/packer/ova/linux/photon/http/3/ks.json) file is hosted by packer by starting an http server. Packer can use one of the opened ports between `8000` and `9000` by default.
+
+## Customization
+
+Packer HTTP server port can be configured using `http_port_max` and `http_port_min` packer variables.
+
+- Only use ports between `8500` and `8550`. Create a new `packer-ports.json` file in [packer variables folder](./../../packer-variables/) with below contents
+
+```JSON
+{
+    "http_port_max": "8500",
+    "http_port_min": "8550"
+}
+```
+
+- Specify a single port `8939`. Create a new `packer-ports.json` file in [packer variables folder](./../../packer-variables/) with below contents
+
+```JSON
+{
+    "http_port_max": "8939",
+    "http_port_min": "8939"
+}
+```

--- a/images/tkg/docs/examples/prometheus_node_exporter.md
+++ b/images/tkg/docs/examples/prometheus_node_exporter.md
@@ -1,0 +1,96 @@
+# Running Prometheus node exporter service on the nodes
+
+## Use case
+
+I want to monitor the nodes using the hardware and OS metrics exposed by Prometheus [Node Exporter](https://prometheus.io/docs/guides/node-exporter/).
+
+## Customization
+
+For this we will create a new ansible task that will create and configure the node exporter service.
+
+- Create unit file for the new service `node_exporter.service` in [ansible files](./../../ansible/files/) folder.
+
+```text
+[Unit]
+Description=Prometheus Node Exporter
+Documentation=https://github.com/prometheus/node_exporter
+After=network-online.target
+
+[Service]
+User=root
+ExecStart=/opt/node_exporter/node_exporter
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+- Create new variables in the [main.yml](./../../ansible/defaults/main.yml) for configuring where to pull the service binary and the version
+
+```yaml
+node_exporter_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+node_exporter_binary: "node_exporter-{{ node_exporter_version }}.linux-amd64"
+node_exporter_location: /opt/node_exporter
+node_exporter_tar: /tmp/node_exporter.tar.gz
+```
+
+- `node_exporter_version` is a ansible variable that can be passed through the `node_exporter_version` packer variable present in [default-args.j2](./../../packer-variables/default-args.j2)
+
+```text
+    "ansible_user_vars": "<existing_values_snip> node_exporter_version=1.4.0 ",
+```
+
+- Open the `9100` for the service (For external services to pull the metrics). Edit the [iptables.rules](./../../ansible/files/iptables.rules)
+
+```text
+-A INPUT -p tcp -m multiport --dports 6443,10250,2379,2380,179,22,10349,10350,10351,10100,9100 -j ACCEPT
+```
+
+- Create the ansible task(`node_exporter.yaml`) for creating the service in [ansible tasks](./../../ansible/tasks/) folder
+
+```yaml
+- name: Download Prometheus node exporter tar file
+  get_url:
+    url: "{{ node_exporter_url }}"
+    dest: "{{ node_exporter_tar }}"
+
+- name: Extracting the Node Exporter binary
+  unarchive:
+    src: "{{ node_exporter_tar }}"
+    remote_src: yes
+    dest: /tmp/
+
+- name: Create node exporter directory
+  file:
+    path: "{{ node_exporter_location }}"
+    state: directory
+
+- name: Renaming node exporter binrary
+  command: mv "/tmp/{{ node_exporter_binary }}/node_exporter" "{{ node_exporter_location }}/"
+
+- name: Create node exporter unit file
+  copy:
+    src: files/node_exporter.service
+    dest: /etc/systemd/system/node_exporter.service
+    mode: 0644
+
+- name: Enable node exporter service
+  systemd:
+    name: node_exporter
+    daemon_reload: yes
+    enabled: yes
+
+- name: Start node_exporter, if not started
+  service:
+    name: node_exporter
+    state: started
+```
+
+- Edit [main.yml](./../../ansible/tasks/main.yml) for adding the tasks to the ansible role.
+
+```yaml
+# At the end of the file
+- import_tasks: node_exporter.yml
+```

--- a/images/tkg/packer-variables/vsphere.j2
+++ b/images/tkg/packer-variables/vsphere.j2
@@ -1,9 +1,9 @@
 {
     {# vCenter server IP or FQDN #}
     "vcenter_server":"",
-    {# SSO administrator username #}
+    {# vCenter username #}
     "username":"",
-    {# SSO administrator password #}
+    {# vCenter user password #}
     "password":"",
     {# Datacenter name where packer creates the VM for customization #}
     "datacenter":"",


### PR DESCRIPTION
## Changes
This PR adds documentation for example customization like
- Adding new packages and configuring repositories or sources.
- Changing the VMX version/Hardware version.
- Configuring the Packer HTTP server port during the image build process.
- Adding a new service like Prometheus node exporter.

Other Changes
- Added a gif on how to build the node image.
- Added reference to the packer documentation for permissions of the vSphere user.

Please refer to the [forked repo](https://github.com/DimpleRajaVamsi/vmware-image-builder/tree/doc_add_new_pkgs/images/tkg) for better UX. 

## Testing
- Made the changes in my forked repo (refer to this [commit](https://github.com/DimpleRajaVamsi/vmware-image-builder/commit/0441ab186bd4a08c8dff5ea4075a6a761ab73da6))
- Built the node image and verified the packages/http port and node exporter service if running or not
```
==> vsphere: Starting HTTP server on port 8939
==> vsphere: Set boot order temporary...
==> vsphere: Power on VM...
==> vsphere: Waiting 10s for boot...
==> vsphere: HTTP server is working at http://*********:8939/
...
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Download Prometheus node exporter tar file] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Extracting the Node Exporter binary] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Create node exporter directory] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Renaming node exporter binrary] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Create node exporter unit file] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Enable node exporter service] ***
    vsphere: changed: [default]
    vsphere:
    vsphere: TASK [/image-builder/images/capi/image/ansible : Start node_exporter, if not started] ***
    vsphere: changed: [default]
```
```
root@tkc-cznz2-w54lg:~# apt list | grep pciutils

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

pciutils/now 1:3.6.4-1ubuntu0.20.04.1 amd64 [installed,local]
root@tkc-cznz2-w54lg:~# systemctl status node_exporter
● node_exporter.service - Prometheus Node Exporter
     Loaded: loaded (/etc/systemd/system/node_exporter.service; enabled; vendor preset: enabled)
     Active: active (running) since Sun 2023-03-12 10:22:08 UTC; 3min 40s ago
       Docs: https://github.com/prometheus/node_exporter
   Main PID: 616 (node_exporter)
      Tasks: 5 (limit: 2346)
     Memory: 5.1M
     CGroup: /system.slice/node_exporter.service
             └─616 /opt/node_exporter/node_exporter

Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.829Z caller=node_exporter.go:115 level=info collector=th>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.829Z caller=node_exporter.go:115 level=info collector=ti>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.829Z caller=node_exporter.go:115 level=info collector=ti>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.830Z caller=node_exporter.go:115 level=info collector=ud>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.830Z caller=node_exporter.go:115 level=info collector=un>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.830Z caller=node_exporter.go:115 level=info collector=vm>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.830Z caller=node_exporter.go:115 level=info collector=xfs
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.830Z caller=node_exporter.go:115 level=info collector=zfs
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.831Z caller=node_exporter.go:199 level=info msg="Listeni>
Mar 12 10:22:09 tkc-cznz2-w54lg node_exporter[616]: ts=2023-03-12T10:22:09.835Z caller=tls_config.go:195 level=info msg="TLS is dis>
root@4211f3e1a643561595f6f6fd2b90d113 [ ~ ]# curl -k http://<VM_IP>:9100/metrics
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
...
```
- VMX version on the control plane VM.
<img width="468" alt="Screenshot 2023-03-12 at 4 08 46 PM" src="https://user-images.githubusercontent.com/10498902/224539748-3263bfc2-b736-4617-9c8e-a9cedaa52549.png">

Closes #8

Signed-off-by: Dimple Raja Vamsi Kosaraju <kosarajud@vmware.com>