### PR TITLE
[TKG]Adding support for building 1.24.9 k8s node images

### DIFF
--- a/images/tkg/supported-versions.json
+++ b/images/tkg/supported-versions.json
@@ -1,6 +1,6 @@
 {
-    "v1.22.13+vmware.1" : {
+    "v1.24.9+vmware.1" : {
         "supported_os": ["photon-3", "ubuntu-2004-efi"],
-        "artifacts_image": "projects-stg.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.22.13_vmware.1-tkg.1"
+        "artifacts_image": "projects-stg.registry.vmware.com/tkg/tkg-vsphere-linux-resource-bundle:v1.24.9_vmware.1-tkg.1"
     }
 }


### PR DESCRIPTION
This PR adds support for 1.24.9 K8s and removes older K8s version support.

Closes #10 

## Testing
With the sandbox build(Image before merging the Bolt MR) I created Photon/Ubunut Node images and tested TKC creation.

Signed-off-by: Dimple Raja Vamsi Kosaraju <kosarajud@vmware.com>