### PR TITLE
adds POS flag pos=1 to kernel command line parameters 

### DIFF
--- a/ansible/tasks/photon.yml
+++ b/ansible/tasks/photon.yml
@@ -26,3 +26,10 @@
     path: /boot/photon.cfg
     regexp: "apparmor=0"
     replace: "apparmor=1"
+
+- name: Enable POS flag in kernel
+  lineinfile:
+    path: /boot/photon.cfg
+    backrefs: yes
+    regexp: "^(?!.*pos=1)(photon_cmdline.*)"
+    line: '\1 pos=1'


### PR DESCRIPTION
This PR fixes https://github.com/vmware/image-builder/issues/19

Adds pos flag pos=1 to kernel parameters to mitigate regression in Pod's Datapath Performance on TKG
Currently, there's a regression in Pod's Datapath performance for the TKG 2.0 TKRs.
Redis throughput degrades by 55%
intra-node TCP bandwidth degrades by 44%
intra-node UDP throughput by 57%

Testing

-  Built the Photon and Ubuntu OVA's
-  Able to get TKC up and running
- Ran gce2e with combinations
       - Photon, Antrea
       - Photon, Calico
       - Ubuntu, Antrea
       - Ubuntu, Calico
